### PR TITLE
Fix embedded `drivercom-cli` not working on Linux

### DIFF
--- a/unpack-drivercom.js
+++ b/unpack-drivercom.js
@@ -52,15 +52,19 @@ try {
       unlink(path.join(base_path, name));
     }
   }
-  await rename(
-    path.join(base_path, binaryName + extension),
-    path.join(base_path, newBinaryName + extension),
-  );
+
+  const to_rename = path.join(base_path, binaryName + extension);
+  const renamed = path.join(base_path, newBinaryName + extension);
+
+  await rename(to_rename, renamed);
   if (platform === "windows") {
     await rename(
       path.join(base_path, binaryName + ".pdb"),
       path.join(base_path, newBinaryName + ".pdb"),
     );
+  } else if (platform === "linux") {
+    // Requires marking file as executable
+    execSync("chmod +x " + renamed);
   }
 } catch (err) {
   console.error(err);


### PR DESCRIPTION
On fetching and unpacking the latest `drivercom-cli`, the resulting binary is not marked with executable permissions on Linux. As such, when the binary is called from the GUI, it fails with an OS permission error.

This PR fixes the issue by adding executable permissions on Linux for the final resulting binary before bundling.