### PR TITLE
Change Monitoring page UI details

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -83,8 +83,20 @@ export default defineConfig({
             },
             customGreen: {
               value: {
-                _light: "#61dc58",
-                _dark: "#54be4c",
+                _light: "#a8dcab",
+                _dark: "#0f6b4c",
+              },
+            },
+            customRed: {
+              value: {
+                _light: "#fdc8c8",
+                _dark: "#bd2f31",
+              },
+            },
+            customOrange: {
+              value: {
+                _light: "#F7ce82",
+                _dark: "#b4820F",
               },
             },
           },

--- a/src/components/System/Axes.tsx
+++ b/src/components/System/Axes.tsx
@@ -81,7 +81,7 @@ export function Axis(props: AxisProps) {
               width="min-content"
               backgroundColor={
                 axisError().overcurrent
-                  ? "red"
+                  ? "accent.customRed"
                   : axisInfo()!.motorEnabled
                     ? "accent.customGreen"
                     : "bg.emphasized"
@@ -91,13 +91,7 @@ export function Axis(props: AxisProps) {
               height="min-content"
               borderWidth="0"
             >
-              <Text
-                color={axisError().overcurrent ? "#ffffff" : "fg.default"}
-                size="sm"
-                fontWeight="medium"
-              >
-                Axis {axisId}
-              </Text>
+              <Text size="sm">Axis {axisId}</Text>
             </Badge>
           </Tooltip.Trigger>
           <Show
@@ -147,7 +141,7 @@ export function Axis(props: AxisProps) {
               height: "0.4rem",
               "margin-top": "0.6rem",
               "border-radius": "1rem",
-              "background-color": "orange",
+              "background-color": "accent.customOrange",
             }}
           />
         </Show>
@@ -174,15 +168,10 @@ export function Axis(props: AxisProps) {
                 size="sm"
                 backgroundColor={
                   !carrier()!.cas || carrier()!.cas!.enabled !== true
-                    ? "orange"
+                    ? "accent.customOrange"
                     : carrier()!.cas!.triggered
                       ? "accent.customGreen"
                       : "bg.emphasized"
-                }
-                color={
-                  !carrier()!.cas || carrier()!.cas!.enabled !== true
-                    ? "white"
-                    : "fg.default"
                 }
               >
                 CAS

--- a/src/components/System/Axes.tsx
+++ b/src/components/System/Axes.tsx
@@ -130,30 +130,44 @@ export function Axis(props: AxisProps) {
           >
             Carrier {carrier()!.id}
           </Text>
-          <Badge
-            style={{
-              width: "min-content",
-              "border-width": "0",
-              "margin-top": "0.2rem",
-            }}
-            size="sm"
-            backgroundColor={
-              carrier()!.cas
-                ? carrier()!.cas!.triggered
-                  ? "red"
-                  : carrier()!.cas!.enabled
-                    ? "accent.customGreen"
-                    : "bg.emphasized"
-                : "bg.emphasized"
-            }
-            color={
-              carrier()!.cas && carrier()!.cas!.triggered
-                ? "white"
-                : "fg.default"
-            }
-          >
-            CAS
-          </Badge>
+          <Tooltip.Root>
+            <Tooltip.Trigger width="min-content">
+              <Badge
+                style={{
+                  width: "min-content",
+                  "border-width": "0",
+                }}
+                size="sm"
+                backgroundColor={
+                  !carrier()!.cas || carrier()!.cas!.enabled !== true
+                    ? "red"
+                    : carrier()!.cas!.triggered
+                      ? "accent.customGreen"
+                      : "bg.emphasized"
+                }
+                color={
+                  !carrier()!.cas || carrier()!.cas!.enabled !== true
+                    ? "white"
+                    : "fg.default"
+                }
+              >
+                CAS
+              </Badge>
+            </Tooltip.Trigger>
+            <Tooltip.Positioner>
+              <Tooltip.Content>
+                <Text>
+                  {carrier()!.cas
+                    ? carrier()!.cas!.triggered
+                      ? "Triggered"
+                      : carrier()!.cas!.enabled
+                        ? "Enabled"
+                        : "Disabled"
+                    : "Disabled"}
+                </Text>
+              </Tooltip.Content>
+            </Tooltip.Positioner>
+          </Tooltip.Root>
         </div>
         <Show when={carrier()!.state}>
           <Stack direction="row" gap="0">

--- a/src/components/System/Axes.tsx
+++ b/src/components/System/Axes.tsx
@@ -1,6 +1,6 @@
 import { Stack } from "styled-system/jsx";
 import { Text } from "../ui/text.tsx";
-import { Show } from "solid-js/web";
+import { For, Show } from "solid-js/web";
 import { useAxesContext } from "./Driver.tsx";
 import { Badge } from "../ui/badge.tsx";
 //@ts-ignore Ignore test in git action
@@ -75,47 +75,81 @@ export function Axis(props: AxisProps) {
         borderColor="bg.muted"
         marginBottom="0.2rem"
       >
-        <Badge
-          width="min-content"
-          backgroundColor={
-            axisError().overcurrent
-              ? "red"
-              : axisInfo()!.motorEnabled
-                ? "accent.customGreen"
-                : "bg.emphasized"
-          }
-          paddingLeft="0.5rem"
-          paddingRight="0.5rem"
-          height="min-content"
-          borderWidth="0"
-        >
-          <Text
-            color={axisError().overcurrent ? "#ffffff" : "fg.default"}
-            size="sm"
-            fontWeight="medium"
+        <Tooltip.Root>
+          <Tooltip.Trigger width="min-content">
+            <Badge
+              width="min-content"
+              backgroundColor={
+                axisError().overcurrent
+                  ? "red"
+                  : axisInfo()!.motorEnabled
+                    ? "accent.customGreen"
+                    : "bg.emphasized"
+              }
+              paddingLeft="0.5rem"
+              paddingRight="0.5rem"
+              height="min-content"
+              borderWidth="0"
+            >
+              <Text
+                color={axisError().overcurrent ? "#ffffff" : "fg.default"}
+                size="sm"
+                fontWeight="medium"
+              >
+                Axis {axisId}
+              </Text>
+            </Badge>
+          </Tooltip.Trigger>
+          <Show
+            when={
+              Object.values(axisInfo()).includes(true) ||
+              Object.values(axisError()).includes(true)
+            }
           >
-            Axis {axisId}
-          </Text>
-        </Badge>
-
+            <Tooltip.Positioner>
+              <Tooltip.Content>
+                <Show when={Object.values(axisInfo()).includes(true)}>
+                  <Text>Info</Text>
+                  <For each={Object.entries(axisInfo())}>
+                    {([key, value]) => {
+                      if (typeof value == "boolean" && value) {
+                        const prettierLabel = `${key[0].toUpperCase()}${key.slice(1, key.length)}`;
+                        return <Text fontWeight="medium">{prettierLabel}</Text>;
+                      }
+                    }}
+                  </For>
+                </Show>
+                <Show when={Object.values(axisError()).includes(true)}>
+                  <Text
+                    marginTop={
+                      Object.values(axisInfo()).includes(true) ? "0.5rem" : "0"
+                    }
+                  >
+                    Error
+                  </Text>
+                  <For each={Object.entries(axisError())}>
+                    {([key, value]) => {
+                      if (key !== "id" && value) {
+                        const prettierLabel = `${key[0].toUpperCase()}${key.slice(1, key.length)}`;
+                        return <Text fontWeight="medium">{prettierLabel}</Text>;
+                      }
+                    }}
+                  </For>
+                </Show>
+              </Tooltip.Content>
+            </Tooltip.Positioner>
+          </Show>
+        </Tooltip.Root>
         <Show when={axisInfo()!.waitingPull || axisInfo()!.waitingPush}>
-          <Badge
-            width="min-content"
-            height="min-content"
-            paddingLeft="0.5rem"
-            paddingRight="0.5rem"
-            borderWidth="0"
-          >
-            <Text width="100%" size="sm">
-              {axisInfo()!.waitingPush
-                ? axisInfo()!.waitingPull
-                  ? "Waiting pull push"
-                  : "Waiting push"
-                : axisInfo()!.waitingPull
-                  ? "Waiting pull"
-                  : ""}
-            </Text>
-          </Badge>
+          <div
+            style={{
+              width: "0.4rem",
+              height: "0.4rem",
+              "margin-top": "0.6rem",
+              "border-radius": "1rem",
+              "background-color": "orange",
+            }}
+          />
         </Show>
       </Stack>
 
@@ -140,7 +174,7 @@ export function Axis(props: AxisProps) {
                 size="sm"
                 backgroundColor={
                   !carrier()!.cas || carrier()!.cas!.enabled !== true
-                    ? "red"
+                    ? "orange"
                     : carrier()!.cas!.triggered
                       ? "accent.customGreen"
                       : "bg.emphasized"

--- a/src/components/System/Axes.tsx
+++ b/src/components/System/Axes.tsx
@@ -41,8 +41,8 @@ export function Axis(props: AxisProps) {
 
   return (
     <Stack
-      width="13rem"
-      height="8rem"
+      width="9rem"
+      height="7rem"
       borderRadius="0.5rem"
       borderWidth="1px"
       borderRightWidth={
@@ -120,15 +120,41 @@ export function Axis(props: AxisProps) {
       </Stack>
 
       <Show when={carrier() && carrier()!.id}>
-        <Text
-          fontWeight="bold"
-          height="1rem"
-          width="100%"
-          color="fg.default"
-          marginBottom="0.5rem"
-        >
-          Carrier {carrier()!.id}
-        </Text>
+        <div style={{ width: "100%", display: "flex" }}>
+          <Text
+            fontWeight="bold"
+            height="1rem"
+            width={`calc(100% - 2rem)`}
+            color="fg.default"
+            marginBottom="0.5rem"
+          >
+            Carrier {carrier()!.id}
+          </Text>
+          <Badge
+            style={{
+              width: "min-content",
+              "border-width": "0",
+              "margin-top": "0.2rem",
+            }}
+            size="sm"
+            backgroundColor={
+              carrier()!.cas
+                ? carrier()!.cas!.triggered
+                  ? "red"
+                  : carrier()!.cas!.enabled
+                    ? "accent.customGreen"
+                    : "bg.emphasized"
+                : "bg.emphasized"
+            }
+            color={
+              carrier()!.cas && carrier()!.cas!.triggered
+                ? "white"
+                : "fg.default"
+            }
+          >
+            CAS
+          </Badge>
+        </div>
         <Show when={carrier()!.state}>
           <Stack direction="row" gap="0">
             <Text width="3rem" size="sm" fontWeight="bold">
@@ -191,17 +217,6 @@ export function Axis(props: AxisProps) {
             >
               {carrier()!.position!.toFixed(6)}
             </Text>
-          </Stack>
-          <Stack direction="row" gap="0">
-            <Text width="3rem" size="sm" fontWeight="bold">
-              CAS
-            </Text>
-            <Show when={carrier()!.cas && carrier()!.cas!.triggered}>
-              <Text size="sm">Triggered</Text>
-            </Show>
-            <Show when={carrier()!.cas && carrier()!.cas!.enabled}>
-              <Text size="sm">Enabled</Text>
-            </Show>
           </Stack>
         </Show>
       </Show>

--- a/src/components/System/Driver.tsx
+++ b/src/components/System/Driver.tsx
@@ -66,10 +66,9 @@ export function Driver(props: DriverProps) {
         <Tooltip.Trigger>
           <Badge
             background={
-              findField(driverError()).length > 0 ? "red" : "bg.canvas"
-            }
-            color={
-              findField(driverError()).length > 0 ? "#ffffff" : "fg.default"
+              findField(driverError()).length > 0
+                ? "accent.customRed"
+                : "bg.canvas"
             }
           >
             <Text fontWeight="bold">Driver {lineCtx.driverIndex + 1}</Text>

--- a/src/components/System/Line.tsx
+++ b/src/components/System/Line.tsx
@@ -75,31 +75,16 @@ export function Line(props: LineProps) {
         padding="0.6rem"
         paddingLeft="1rem"
         paddingRight="1rem"
+        justifyContent="left"
       >
         <Accordion.ItemIndicator class="cancel">
           <ChevronDownIcon />
         </Accordion.ItemIndicator>
-        <Show
-          when={
-            (props.system &&
-              props.system.axisErrors &&
-              findErrorField(props.system.axisErrors).length > 0) ||
-            (props.system &&
-              props.system.driverErrors &&
-              findErrorField(props.system.driverErrors).length > 0)
-          }
-        >
-          <div
-            style={{
-              width: "0.5rem",
-              height: "0.5rem",
-              "background-color": "red",
-              "border-radius": "1rem",
-            }}
-          />
-        </Show>
+
         <Tooltip.Root positioning={{ placement: "bottom-start" }}>
-          <Tooltip.Trigger style={{ width: "100%", "text-align": "left" }}>
+          <Tooltip.Trigger
+            style={{ width: "min-content", "text-align": "left" }}
+          >
             <Text>{props.line.name}</Text>
           </Tooltip.Trigger>
           <Show
@@ -141,6 +126,26 @@ export function Line(props: LineProps) {
             </Tooltip.Positioner>
           </Show>
         </Tooltip.Root>
+        <Show
+          when={
+            (props.system &&
+              props.system.axisErrors &&
+              findErrorField(props.system.axisErrors).length > 0) ||
+            (props.system &&
+              props.system.driverErrors &&
+              findErrorField(props.system.driverErrors).length > 0)
+          }
+        >
+          <Stack
+            backgroundColor="red.9"
+            style={{
+              width: "0.5rem",
+              height: "0.5rem",
+              "border-radius": "1rem",
+              "margin-top": "0.3rem",
+            }}
+          />
+        </Show>
       </Accordion.ItemTrigger>
       <Accordion.ItemContent
         padding="0.5rem"

--- a/src/pages/Monitoring.tsx
+++ b/src/pages/Monitoring.tsx
@@ -231,9 +231,13 @@ function Monitoring() {
   return (
     <>
       <Splitter.Root
+        id={clientId()}
         panels={[
           { id: `${clientId()}-panel` },
-          { id: `${clientId()}-sidebar` },
+          {
+            id: `${clientId()}-sidebar`,
+            minSize: 18,
+          },
         ]}
         size={[panelSize(), 100 - panelSize()]}
         onResize={(details) => {
@@ -259,13 +263,15 @@ function Monitoring() {
           size="sm"
           variant="ghost"
           onClick={() => setShowSideBar(!showSideBar())}
+          position="absolute"
+          top="0"
+          right="0"
         >
           <Show when={!showSideBar()} fallback={<IconChevronRightPipe />}>
             <IconChevronLeftPipe />
           </Show>
         </IconButton>
 
-        {/* Side bar */}
         <Show when={showSideBar()}>
           <Splitter.ResizeTrigger
             id={`${clientId()}-panel:${clientId()}-sidebar`}
@@ -278,14 +284,11 @@ function Monitoring() {
               "border-inline-width": "2px",
             }}
           />
-        </Show>
-
-        <Show when={showSideBar()}>
           <Splitter.Panel
-            minWidth="18rem"
             id={`${clientId()}-sidebar`}
             borderWidth="0"
             backgroundColor="transparent"
+            minWidth="18rem"
           >
             <div style={{ width: "100%", height: "100%" }}>
               {/* Connect Area */}


### PR DESCRIPTION
closes: #217 

**Changed Details**
1. Monitoring page axis width became narrow
2. Carrier CAS UI was text, but now change to badge like Axis badge.
3. Move Monitoring page side bar shrink button to top-right.

**Previous**
<img width="1816" height="874" alt="image" src="https://github.com/user-attachments/assets/8d3fe86b-b594-4fa9-af07-d66c94414ee5" />

**After Changes**
<img width="1713" height="874" alt="image" src="https://github.com/user-attachments/assets/2534c6c1-171e-41b5-87c3-9add9a6832a0" />
